### PR TITLE
fix: in 07-bootstrapping, wget etcd version mismatch

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -22,7 +22,7 @@ gcloud compute ssh controller-0
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.4.10/etcd-v3.4.10-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.4.15/etcd-v3.4.15-linux-amd64.tar.gz"
 ```
 
 `etcd`サーバと`etcdctl`コマンドを展開してインストールします:


### PR DESCRIPTION
`07-bootstrapping-etcd.md`において、fetchしてくる`etcd`のバージョンが後段の処理と不一致していたので修正。

（プルリクの出し方間違えていたらすみません、、、）