### PR TITLE
fix 07-bootstrapping-etcd.md etcd url

### DIFF
--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -22,7 +22,7 @@ gcloud compute ssh controller-0
 
 ```
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.4.10/etcd-v3.4.10-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.4.15/etcd-v3.4.15-linux-amd64.tar.gz"
 ```
 
 `etcd`サーバと`etcdctl`コマンドを展開してインストールします:


### PR DESCRIPTION
07-bootstrapping-etcd.md
Download the official etcd release binaries from the etcd GitHub project:
のURLのバージョンが古く、後のコマンドと一致しないように見えましたので、PRさせて頂きます。
